### PR TITLE
:sparkles: 实现了发布采集表功能

### DIFF
--- a/src/main/java/com/practicum/neuron/config/SecurityConfig.java
+++ b/src/main/java/com/practicum/neuron/config/SecurityConfig.java
@@ -53,16 +53,12 @@ public class SecurityConfig {
     private JwtAuthenticationTokenFilter jwtAuthenticationTokenFilter;
 
     // 登录 api 入口
-    @Value("${api.account.login}")
+    @Value("/api/account/login")
     private String loginUrl;
 
     // 登出 api 入口
-    @Value("${api.account.logout}")
+    @Value("/api/account/logout")
     private String logoutUrl;
-
-    // 注册 api 入口
-    @Value("${api.account.register}")
-    private String registerUrl;
 
     @Bean
     public SecurityFilterChain securityFilterChain(

--- a/src/main/java/com/practicum/neuron/controller/AccountController.java
+++ b/src/main/java/com/practicum/neuron/controller/AccountController.java
@@ -35,7 +35,7 @@ public class AccountController {
     @Resource
     private AccountService accountService;
 
-    @PostMapping("${api.account.register}")
+    @PostMapping("/api/account/register")
     public ResponseEntity<ResponseBody> register(HttpServletRequest request)
             throws IOException {
         JsonNode jsonNode = objectMapper.readTree(request.getInputStream());

--- a/src/main/java/com/practicum/neuron/controller/JwtController.java
+++ b/src/main/java/com/practicum/neuron/controller/JwtController.java
@@ -25,7 +25,7 @@ public class JwtController {
      * @param request HTTP请求
      * @return 新的 accessToken
      */
-    @PostMapping("${api.refresh.access-token}")
+    @PostMapping("/api/refresh/access-token")
     public ResponseEntity<ResponseBody> refreshAccessToken(HttpServletRequest request) {
         String token = jwtUtil.getToken(request);
         String username = jwtUtil.getUserNameFromToken(token);
@@ -39,11 +39,13 @@ public class JwtController {
      * @param request HTTP请求
      * @return 新的 refreshToken
      */
-    @PostMapping("${api.refresh.refresh-token}")
+    @PostMapping("/api/refresh/refresh-token")
     public ResponseEntity<ResponseBody> refreshRefreshToken(HttpServletRequest request) {
         String token = jwtUtil.getToken(request);
         String username = jwtUtil.getUserNameFromToken(token);
         ResponseBody data = new ResponseBody(Status.SUCCESS, jwtUtil.createAccessToken(username));
+        // 注销令牌
+        jwtUtil.blockToken(token, token, username);
         return new ResponseEntity<>(data, HttpStatus.OK);
     }
 }

--- a/src/main/java/com/practicum/neuron/entity/ReleaseInfo.java
+++ b/src/main/java/com/practicum/neuron/entity/ReleaseInfo.java
@@ -1,0 +1,38 @@
+package com.practicum.neuron.entity;
+
+import lombok.Builder;
+import lombok.Builder.Default;
+import lombok.Data;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.index.Indexed;
+import org.springframework.data.mongodb.core.mapping.Document;
+import org.springframework.data.mongodb.core.mapping.Field;
+
+import java.time.LocalDateTime;
+
+@Data
+@Builder
+@Document("release_info")
+public class ReleaseInfo {
+    @Id
+    private String id;
+
+    // 表 tableId
+    @Indexed
+    @Field("table_id")
+    private String tableId;
+
+    // 开始日期, 默认为现在
+    @Default
+    @Field("beginning")
+    private LocalDateTime beginning = LocalDateTime.now();
+
+    // 结束日期, 默认为最大值，即没有结束日期
+    @Default
+    @Field("deadline")
+    private LocalDateTime deadline = LocalDateTime.MIN;
+
+    // 填写规则, 默认为无
+    @Field("fill_rule")
+    private FillRule fillRule;
+}

--- a/src/main/java/com/practicum/neuron/entity/question/ListQuestion.java
+++ b/src/main/java/com/practicum/neuron/entity/question/ListQuestion.java
@@ -11,17 +11,17 @@ import java.util.List;
 @EqualsAndHashCode(callSuper = false)
 @Data
 public class ListQuestion extends Question {
-    @Field("column_heading_list")
-    List<String> columnHeadingList;
+    @Field("row_heading_list")
+    List<String> rowHeadingList;
 
     public ListQuestion() {
         super(QuestionType.LIST_QUESTION);
-        columnHeadingList = new ArrayList<String>();
+        rowHeadingList = new ArrayList<>();
     }
 
     public ListQuestion(String tittle, List<String> columnHeadingList) {
         super(QuestionType.LIST_QUESTION, tittle);
-        this.columnHeadingList = columnHeadingList;
+        this.rowHeadingList = columnHeadingList;
     }
 
     @Override
@@ -29,7 +29,7 @@ public class ListQuestion extends Question {
         Document doc = new Document();
         doc.append("type", getType());
         doc.append("title", getTitle());
-        doc.append("columnHeadingList", columnHeadingList);
+        doc.append("columnHeadingList", rowHeadingList);
         return doc;
     }
 }

--- a/src/main/java/com/practicum/neuron/entity/response/Status.java
+++ b/src/main/java/com/practicum/neuron/entity/response/Status.java
@@ -51,8 +51,13 @@ public class Status {
     public final static Status ACCESS_NO_AUTHORITY = new Status(3004, "当前用户没有访问权限");
     public final static Status ACCESS_CREDENTIAL_EXPIRED = new Status(3005, "登录凭据已过期");
     public final static Status ACCESS_INVALID_TOKEN = new Status(3006, "无效的Token");
+    public final static Status ACCESS_INVALID_PARAMETER = new Status(3007, "无效的参数");
 
     /* 4XXX 数据采集表错误 */
     public final static Status TABLE_UNKNOWN_ERROR = new Status(4000, "未知采集表错误");
     public final static Status TABLE_NOT_EXIST = new Status(4001, "数据采集表不存在");
+    public final static Status TABLE_UNPUBLISHED = new Status(4002, "数据采集表未发布");
+    public final static Status TABLE_ALREADY_PUBLISHED = new Status(4003, "数据采集表已发布");
+    public final static Status TABLE_ALREADY_END = new Status(4004, "数据采集表已结束收集");
+    public final static Status TABLE_INVALID_TIME = new Status(4005, "无效的时间参数");
 }

--- a/src/main/java/com/practicum/neuron/entity/table/Table.java
+++ b/src/main/java/com/practicum/neuron/entity/table/Table.java
@@ -7,15 +7,15 @@ import org.springframework.data.annotation.Id;
 import org.springframework.data.mongodb.core.mapping.Document;
 import org.springframework.data.mongodb.core.mapping.Field;
 
+import java.time.LocalDateTime;
 import java.util.ArrayList;
-import java.util.Date;
 import java.util.List;
 
 @Data
 @Builder
 @Document("tables")
 public class Table {
-    // id
+    // tableId
     @Id
     private String id;
 
@@ -30,7 +30,7 @@ public class Table {
     // 更新时间，默认为创建时间
     @Default
     @Field("update_date")
-    private Date updateDate = new Date();
+    private LocalDateTime updateDate = LocalDateTime.now();
 
     // 问题列表，一开始为空
     @Default

--- a/src/main/java/com/practicum/neuron/exception/TableAlreadyEndException.java
+++ b/src/main/java/com/practicum/neuron/exception/TableAlreadyEndException.java
@@ -1,0 +1,8 @@
+package com.practicum.neuron.exception;
+
+public class TableAlreadyEndException extends Exception {
+    @Override
+    public String getMessage() {
+        return "数据采集表已结束收集";
+    }
+}

--- a/src/main/java/com/practicum/neuron/exception/TableAlreadyPublishedException.java
+++ b/src/main/java/com/practicum/neuron/exception/TableAlreadyPublishedException.java
@@ -1,0 +1,8 @@
+package com.practicum.neuron.exception;
+
+public class TableAlreadyPublishedException extends Exception {
+    @Override
+    public String getMessage() {
+        return "数据采集表已发布";
+    }
+}

--- a/src/main/java/com/practicum/neuron/exception/TableUnpublishException.java
+++ b/src/main/java/com/practicum/neuron/exception/TableUnpublishException.java
@@ -1,0 +1,8 @@
+package com.practicum.neuron.exception;
+
+public class TableUnpublishException extends Exception {
+    @Override
+    public String getMessage() {
+        return "采集表未发布";
+    }
+}

--- a/src/main/java/com/practicum/neuron/handler/LoginSuccessHandler.java
+++ b/src/main/java/com/practicum/neuron/handler/LoginSuccessHandler.java
@@ -36,7 +36,6 @@ public class LoginSuccessHandler implements AuthenticationSuccessHandler {
         Map<String, Object> data = new HashMap<>();
         data.put("refresh_token", refreshToken);
         data.put("access_token", accessToken);
-        data.put("username", user.getUsername());
         data.put("role", user.getRole());
         response.getWriter().write(new ResponseBody(Status.SUCCESS, data).toJson());
         response.getWriter().flush();

--- a/src/main/java/com/practicum/neuron/mapper/ReleaseInfoMapper.java
+++ b/src/main/java/com/practicum/neuron/mapper/ReleaseInfoMapper.java
@@ -1,0 +1,8 @@
+package com.practicum.neuron.mapper;
+
+import com.practicum.neuron.entity.ReleaseInfo;
+import org.springframework.data.mongodb.repository.MongoRepository;
+
+public interface ReleaseInfoMapper extends MongoRepository<ReleaseInfo, String> {
+    void deleteByTableId(String id);
+}

--- a/src/main/java/com/practicum/neuron/service/DesignService.java
+++ b/src/main/java/com/practicum/neuron/service/DesignService.java
@@ -2,11 +2,14 @@ package com.practicum.neuron.service;
 
 import com.practicum.neuron.entity.FillRule;
 import com.practicum.neuron.entity.question.Question;
+import com.practicum.neuron.exception.TableAlreadyEndException;
+import com.practicum.neuron.exception.TableAlreadyPublishedException;
 import com.practicum.neuron.exception.TableNotExistException;
+import com.practicum.neuron.exception.TableUnpublishException;
 import org.bson.Document;
 import org.springframework.stereotype.Service;
 
-import java.util.Date;
+import java.time.LocalDateTime;
 import java.util.List;
 
 /**
@@ -20,7 +23,7 @@ public interface DesignService {
      *
      * @param tittle 表标题
      * @param author 创建者
-     * @return 采集表 id
+     * @return 采集表 tableId
      */
     String createTable(String tittle, String author);
 
@@ -28,33 +31,41 @@ public interface DesignService {
      * 更新指定采集表的问题列表
      *
      * @param id        采集表 id
+     * @param title     采集表标题
      * @param questions 问题列表, 实际的类型是 Question 及其子类
      * @see Question
      */
-    void updateQuestion(String id, List<Document> questions) throws TableNotExistException;
-
+    void updateQuestion(String id, String title, List<Document> questions)
+            throws TableNotExistException, TableAlreadyPublishedException;
 
     /**
      * 发布表
      *
-     * @param id       采集表 id
-     * @param deadline 截止日期
-     * @param rule     填写规则约束
+     * @param id        采集表 tableId
+     * @param beginning 开始日期
+     * @param deadline  截止日期
+     * @param rule      填写规则约束
      * @see FillRule
      */
-    void releaseTable(int id, Date deadline, FillRule rule);
+    void releaseTable(String id, LocalDateTime beginning, LocalDateTime deadline, FillRule rule)
+            throws TableNotExistException, TableAlreadyPublishedException, TableAlreadyEndException;
 
+    /**
+     * 暂停发布
+     *
+     * @param id 采集表 tableId
+     */
+    void stopRelease(String id) throws TableUnpublishException, TableAlreadyEndException, TableNotExistException;
 
     /**
      * 删除表
      *
-     * @param id 采集表 id
+     * @param id 采集表 tableId
      */
-    void deleteTable(int id);
-
+    void deleteTable(String id) throws TableNotExistException;
 
     //List<TableSummary> getTableSummary();
 
 
-    //Table getTable(int id);
+    //Table getTable(int tableId);
 }

--- a/src/main/java/com/practicum/neuron/serviceImpl/DesignServiceImpl.java
+++ b/src/main/java/com/practicum/neuron/serviceImpl/DesignServiceImpl.java
@@ -1,8 +1,14 @@
 package com.practicum.neuron.serviceImpl;
 
 import com.practicum.neuron.entity.FillRule;
+import com.practicum.neuron.entity.ReleaseInfo;
 import com.practicum.neuron.entity.table.Table;
+import com.practicum.neuron.entity.table.TableStatus;
+import com.practicum.neuron.exception.TableAlreadyEndException;
+import com.practicum.neuron.exception.TableAlreadyPublishedException;
 import com.practicum.neuron.exception.TableNotExistException;
+import com.practicum.neuron.exception.TableUnpublishException;
+import com.practicum.neuron.mapper.ReleaseInfoMapper;
 import com.practicum.neuron.mapper.TableMapper;
 import com.practicum.neuron.service.DesignService;
 import jakarta.annotation.Resource;
@@ -10,7 +16,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.bson.Document;
 import org.springframework.stereotype.Component;
 
-import java.util.Date;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -19,6 +25,9 @@ import java.util.Optional;
 public class DesignServiceImpl implements DesignService {
     @Resource
     private TableMapper tableMapper;
+
+    @Resource
+    private ReleaseInfoMapper releaseInfoMapper;
 
     @Override
     public String createTable(String tittle, String author) {
@@ -31,12 +40,18 @@ public class DesignServiceImpl implements DesignService {
     }
 
     @Override
-    public void updateQuestion(String id, List<Document> questions) throws TableNotExistException {
+    public void updateQuestion(String id, String title, List<Document> questions)
+            throws TableNotExistException, TableAlreadyPublishedException {
         Optional<Table> t = tableMapper.findById(id);
         if(t.isPresent()) {
             Table table = t.get();
-            table.setUpdateDate(new Date());
+            if (table.getStatus().equals(TableStatus.PUBLISHING)) {
+                throw new TableAlreadyPublishedException();
+            }
+            table.setTittle(title);
+            table.setUpdateDate(LocalDateTime.now());
             table.setQuestions(questions);
+            table.setStatus(TableStatus.UNPUBLISH);
             tableMapper.save(table);
         }
         else {
@@ -45,12 +60,49 @@ public class DesignServiceImpl implements DesignService {
     }
 
     @Override
-    public void releaseTable(int id, Date deadline, FillRule rule) {
-
+    public void releaseTable(String id, LocalDateTime beginning, LocalDateTime deadline, FillRule rule)
+            throws TableNotExistException, TableAlreadyPublishedException, TableAlreadyEndException {
+        Optional<Table> t = tableMapper.findById(id);
+        if(t.isPresent()) {
+            Table table = t.get();
+            switch (table.getStatus()) {
+                case UNPUBLISH -> table.setStatus(TableStatus.PUBLISHING);
+                case PUBLISHING -> throw new TableAlreadyPublishedException();
+                case END -> throw new TableAlreadyEndException();
+            }
+            tableMapper.save(table);
+            ReleaseInfo info = ReleaseInfo.builder()
+                    .tableId(id)
+                    .beginning(beginning)
+                    .deadline(deadline)
+                    .build();
+            releaseInfoMapper.insert(info);
+        }
+        else {
+            throw new TableNotExistException();
+        }
     }
 
     @Override
-    public void deleteTable(int id) {
+    public void stopRelease(String id) throws TableUnpublishException, TableAlreadyEndException, TableNotExistException {
+        Optional<Table> t = tableMapper.findById(id);
+        if(t.isPresent()) {
+            Table table = t.get();
+            switch (table.getStatus()) {
+                case UNPUBLISH -> throw new TableUnpublishException();
+                case PUBLISHING -> table.setStatus(TableStatus.UNPUBLISH);
+                case END -> throw new TableAlreadyEndException();
+            }
+            releaseInfoMapper.deleteByTableId(id);
+            tableMapper.save(table);
+        }
+        else {
+            throw new TableNotExistException();
+        }
+    }
+
+    @Override
+    public void deleteTable(String id) throws TableNotExistException {
 
     }
 }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -35,21 +35,5 @@ jwt:
 mybatis:
   mapper-locations: classpath:mapper/*
 
-api:
-  account:
-    login: '/api/account/login'
-    logout: '/api/account/logout'
-    register: '/api/account/register'
-  refresh:
-    access-token: '/api/refresh/access-token'
-    refresh-token: '/api/refresh/refresh-token'
-  admin:
-    table:
-      get: '/api/admin/table/get'
-      create: '/api/admin/table/create'
-      release: '/api/admin/table/release'
-      delete: '/api/admin/table/delete'
-    question:
-      update: '/api/admin/question/update'
 
 

--- a/src/test/resources/sql/user.sql
+++ b/src/test/resources/sql/user.sql
@@ -33,4 +33,4 @@ VALUES
 INSERT INTO security_info (username, email)
 VALUES
     ('test1', 'communicationGCY@outlook.com'),
-    ('test2', 'communicationGCY@outlook.com')
+    ('test2', 'communicationGCY@outlook.com');


### PR DESCRIPTION
- 实现了发布采集表和暂停发布的功能

- 重新规范了 api 接口使其符合 RESTful 风格要求

- 接口 url 重新在代码中写入，而不是在写入配置文件中，实践表明写入配置文件中并不能提高可维护性

Close Issue #8